### PR TITLE
Add Parse tracing

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -99,7 +99,7 @@ func doRun(options *runOptions) func(cmd *cli.Command, args []string) error {
 			return stdoutWriter.Flush()
 		}
 
-		parser := parser.New(src, string(contents))
+		parser := parser.New(src, string(contents), options.debug)
 		program, err := parser.Parse()
 		if err != nil {
 			return err

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -59,14 +59,20 @@ func runCommand() (*cli.Command, error) {
 	)
 }
 
+type replOptions struct {
+	debug bool // Emit debug information
+}
+
 // replCommand returns the repl subcommand.
 func replCommand() (*cli.Command, error) {
+	var options replOptions
 	return cli.New(
 		"repl",
 		cli.Short("Start an interactive REPL for Lox"),
 		cli.Allow(cli.NoArgs()),
+		cli.Flag(&options.debug, "debug", cli.NoShortHand, false, "Emit debug information"),
 		cli.Run(func(cmd *cli.Command, args []string) error {
-			return repl.Start(os.Stdin, os.Stdout)
+			return repl.Start(os.Stdin, os.Stdout, options.debug)
 		}),
 	)
 }
@@ -99,7 +105,7 @@ func doRun(options *runOptions) func(cmd *cli.Command, args []string) error {
 			return stdoutWriter.Flush()
 		}
 
-		parser := parser.New(src, string(contents), options.debug)
+		parser := parser.New(src, string(contents), options.debug, os.Stderr)
 		program, err := parser.Parse()
 		if err != nil {
 			return err

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/FollowTheProcess/glox/internal/syntax/parser"
 )
@@ -12,7 +13,7 @@ import (
 const prompt = "-> "
 
 // Start starts the REPL, reading from in and printing to out.
-func Start(in io.Reader, out io.Writer) error {
+func Start(in io.Reader, out io.Writer, trace bool) error {
 	scanner := bufio.NewScanner(in)
 
 	for {
@@ -24,7 +25,7 @@ func Start(in io.Reader, out io.Writer) error {
 		}
 
 		line := scanner.Text()
-		p := parser.New("REPL", line, false)
+		p := parser.New("REPL", line, trace, os.Stderr)
 
 		program, err := p.Parse()
 		if err != nil {

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -24,7 +24,7 @@ func Start(in io.Reader, out io.Writer) error {
 		}
 
 		line := scanner.Text()
-		p := parser.New("REPL", line)
+		p := parser.New("REPL", line, false)
 
 		program, err := p.Parse()
 		if err != nil {

--- a/internal/syntax/parser/parser.go
+++ b/internal/syntax/parser/parser.go
@@ -4,7 +4,9 @@ package parser
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
+	"strings"
 
 	"github.com/FollowTheProcess/glox/internal/syntax/ast"
 	"github.com/FollowTheProcess/glox/internal/syntax/lexer"
@@ -25,22 +27,25 @@ import (
 
 // Parser is the glox parser.
 type Parser struct {
-	name      string       // The name of the source file or "stdin" if REPL
-	tokeniser *lexer.Lexer // The lexer
-	src       string       // The raw source code
-	errs      []error      // List of [SyntaxError], collected while parsing
-	current   token.Token  // The current token the parser is sat on
-	next      token.Token  // The next token in the stream
-	trace     bool         // Output parse traces
+	traceWriter io.Writer
+	tokeniser   *lexer.Lexer
+	name        string
+	src         string
+	errs        []error
+	current     token.Token
+	next        token.Token
+	indent      int
+	trace       bool
 }
 
 // New returns a new Parser.
-func New(name, src string, trace bool) *Parser {
+func New(name, src string, trace bool, traceWriter io.Writer) *Parser {
 	parser := &Parser{
-		name:      name,
-		src:       src,
-		tokeniser: lexer.New(src),
-		trace:     trace,
+		name:        name,
+		src:         src,
+		tokeniser:   lexer.New(src),
+		trace:       trace,
+		traceWriter: traceWriter,
 	}
 
 	// Read 2 tokens so current and next are set
@@ -50,10 +55,29 @@ func New(name, src string, trace bool) *Parser {
 	return parser
 }
 
+// Parse is the top level parsing method, and will parse an entire Lox
+// source file to completion.
+func (p *Parser) Parse() (ast.Program, error) {
+	prog := ast.Program{}
+	for !p.current.Is(token.EOF) {
+		statement := p.parseStatement()
+		if statement != nil && len(p.errs) == 0 {
+			prog.Statements = append(prog.Statements, statement)
+		}
+		p.advance()
+	}
+
+	return prog, errors.Join(p.errs...)
+}
+
 // advance advances the parser by a single token.
 func (p *Parser) advance() {
 	p.current = p.next
 	p.next = p.tokeniser.NextToken()
+
+	if p.trace {
+		p.printTrace("current: " + p.current.String())
+	}
 }
 
 // expect asserts that the next token is of a particular kind, appending a syntax
@@ -85,11 +109,10 @@ func (p *Parser) expect(kind token.Kind) {
 	)
 }
 
-// syntaxError emits a [SyntaxError], populating it with line/col info using
-// the parser's current state.
-func (p *Parser) syntaxError(format string, args ...any) {
-	// Calculate line and col based on the offending token's offset
-	line := 1              // Line counter
+// position calculates the parser's current position based on the offset of the
+// p.current token, returning it as line and column information.
+func (p *Parser) position() (line, col int) {
+	line = 1               // Line counter
 	lastNewLineOffset := 0 // The byte offset of the last newline seen
 	for index, byt := range p.src {
 		if byt == '\n' {
@@ -104,11 +127,25 @@ func (p *Parser) syntaxError(format string, args ...any) {
 
 	// The column is therefore the number of bytes from the position of the most recent newline
 	// encountered before the token, and the offset of the token itself
-	col := p.current.Start - lastNewLineOffset
+	col = p.current.Start - lastNewLineOffset
+
+	return line, col
+}
+
+// syntaxError emits a [SyntaxError], populating it with line/col info using
+// the parser's current state.
+func (p *Parser) syntaxError(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if p.trace {
+		p.startTrace("error: " + msg)
+		defer p.endTrace()
+	}
+
+	line, col := p.position()
 
 	err := SyntaxError{
 		File:  p.name,
-		Msg:   fmt.Sprintf(format, args...),
+		Msg:   msg,
 		Token: p.current,
 		Line:  line,
 		Col:   col,
@@ -117,23 +154,39 @@ func (p *Parser) syntaxError(format string, args ...any) {
 	p.errs = append(p.errs, err)
 }
 
-// Parse is the top level parsing method, and will parse an entire Lox
-// source file to completion.
-func (p *Parser) Parse() (ast.Program, error) {
-	prog := ast.Program{}
-	for !p.current.Is(token.EOF) {
-		statement := p.parseStatement()
-		if statement != nil && len(p.errs) == 0 {
-			prog.Statements = append(prog.Statements, statement)
-		}
-		p.advance()
-	}
+// printTrace outputs a parser trace to stderr.
+func (p *Parser) printTrace(a ...any) {
+	const padding = 2 // Indent multiplier
 
-	return prog, errors.Join(p.errs...)
+	line, col := p.position()
+	fmt.Fprintf(p.traceWriter, "%5d:%3d: ", line, col)
+	fmt.Fprint(p.traceWriter, strings.Repeat(".", padding*p.indent))
+	fmt.Fprintln(p.traceWriter, a...)
+}
+
+// startTrace starts a parser trace.
+func (p *Parser) startTrace(msg string) {
+	p.printTrace(msg, "(")
+	p.indent++
+}
+
+// endTrace ends a parser trace.
+//
+// Usage:
+//
+//	p.startTrace("message")
+//	defer p.endTrace()
+func (p *Parser) endTrace() {
+	p.indent--
+	p.printTrace(")")
 }
 
 // parseStatement parses statements of all kinds.
 func (p *Parser) parseStatement() ast.Statement {
+	if p.trace {
+		p.startTrace("Statement")
+		defer p.endTrace()
+	}
 	switch p.current.Kind {
 	case token.Var:
 		return p.parseVarDecl()
@@ -153,6 +206,11 @@ func (p *Parser) Errors() []error {
 
 // parseVarDecl parses a `var <ident> = <expr>` statement.
 func (p *Parser) parseVarDecl() ast.Statement {
+	if p.trace {
+		p.startTrace("VarDecl")
+		defer p.endTrace()
+	}
+
 	var statement ast.VarStatement
 	p.expect(token.Ident)
 	statement.Ident = ast.Ident{Tok: p.current, Name: p.src[p.current.Start:p.current.End]}
@@ -169,6 +227,11 @@ func (p *Parser) parseVarDecl() ast.Statement {
 
 // parseReturnStatement parses a `return <expr>;` statement.
 func (p *Parser) parseReturnStatement() ast.Statement {
+	if p.trace {
+		p.startTrace("ReturnStatement")
+		defer p.endTrace()
+	}
+
 	statement := ast.ReturnStatement{Tok: p.current}
 
 	p.advance()
@@ -181,6 +244,11 @@ func (p *Parser) parseReturnStatement() ast.Statement {
 
 // parsePrintStatement parses a `print <expr>;` statement.
 func (p *Parser) parsePrintStatement() ast.Statement {
+	if p.trace {
+		p.startTrace("PrintStatement")
+		defer p.endTrace()
+	}
+
 	statement := ast.PrintStatement{Tok: p.current}
 
 	p.advance()
@@ -194,6 +262,11 @@ func (p *Parser) parsePrintStatement() ast.Statement {
 // parseExpressionStatement parses a generic expression statement
 // i.e. `<expr>;`.
 func (p *Parser) parseExpressionStatement() ast.Statement {
+	if p.trace {
+		p.startTrace("ExpressionStatement")
+		defer p.endTrace()
+	}
+
 	statement := ast.ExpressionStatement{Tok: p.current}
 	statement.Value = p.parseExpression(token.PrecedenceMin)
 
@@ -207,6 +280,11 @@ func (p *Parser) parseExpressionStatement() ast.Statement {
 // parseExpression is the top level parse function for precedence based
 // expression parsing.
 func (p *Parser) parseExpression(precedence int) ast.Expression {
+	if p.trace {
+		p.startTrace("Expression")
+		defer p.endTrace()
+	}
+
 	var expression ast.Expression
 
 	switch p.current.Kind {
@@ -250,11 +328,23 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	return expression
 }
 
+// TODO(@FollowTheProcess): Do we return concrete structs from these?
+
 func (p *Parser) parseIdentifierExpression() ast.Expression {
+	if p.trace {
+		p.startTrace("Ident")
+		defer p.endTrace()
+	}
+
 	return ast.Ident{Tok: p.current, Name: p.src[p.current.Start:p.current.End]}
 }
 
 func (p *Parser) parseNumberLiteralExpression() ast.Expression {
+	if p.trace {
+		p.startTrace("Number")
+		defer p.endTrace()
+	}
+
 	src := p.src[p.current.Start:p.current.End]
 	n, err := strconv.ParseFloat(src, 64)
 	if err != nil {
@@ -266,6 +356,11 @@ func (p *Parser) parseNumberLiteralExpression() ast.Expression {
 }
 
 func (p *Parser) parseBoolLiteralExpression() ast.Expression {
+	if p.trace {
+		p.startTrace("Bool")
+		defer p.endTrace()
+	}
+
 	src := p.src[p.current.Start:p.current.End]
 	v, err := strconv.ParseBool(src)
 	if err != nil {
@@ -278,6 +373,10 @@ func (p *Parser) parseBoolLiteralExpression() ast.Expression {
 // parseUnaryExpression parses a unary expression
 // i.e. `!true`.
 func (p *Parser) parseUnaryExpression() ast.Expression {
+	if p.trace {
+		p.startTrace("UnaryExpression")
+		defer p.endTrace()
+	}
 	expression := ast.UnaryExpression{Tok: p.current}
 
 	p.advance()
@@ -290,6 +389,11 @@ func (p *Parser) parseUnaryExpression() ast.Expression {
 // parseBinaryExpression parses a binary expression
 // i.e. `x != y` or `5 + 5`.
 func (p *Parser) parseBinaryExpression(left ast.Expression) ast.Expression {
+	if p.trace {
+		p.startTrace("BinaryExpression")
+		defer p.endTrace()
+	}
+
 	expression := ast.BinaryExpression{Left: left, Op: p.current}
 
 	precedence := p.current.Precedence()
@@ -302,6 +406,11 @@ func (p *Parser) parseBinaryExpression(left ast.Expression) ast.Expression {
 // parseGroupedExpression parses a parenthesised expression
 // i.e. `(x + y)`.
 func (p *Parser) parseGroupedExpression() ast.Expression {
+	if p.trace {
+		p.startTrace("GroupedExpression")
+		defer p.endTrace()
+	}
+
 	expression := ast.GroupedExpression{LParen: p.current}
 	p.advance()
 	inner := p.parseExpression(token.PrecedenceMin)

--- a/internal/syntax/parser/parser.go
+++ b/internal/syntax/parser/parser.go
@@ -31,14 +31,16 @@ type Parser struct {
 	errs      []error      // List of [SyntaxError], collected while parsing
 	current   token.Token  // The current token the parser is sat on
 	next      token.Token  // The next token in the stream
+	trace     bool         // Output parse traces
 }
 
 // New returns a new Parser.
-func New(name, src string) *Parser {
+func New(name, src string, trace bool) *Parser {
 	parser := &Parser{
 		name:      name,
 		src:       src,
 		tokeniser: lexer.New(src),
+		trace:     trace,
 	}
 
 	// Read 2 tokens so current and next are set
@@ -223,7 +225,7 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		return nil
 	}
 
-	for !p.next.Is(token.SemiColon) && precedence < p.next.Precedence() {
+	for !p.next.Is(token.SemiColon) && p.next.Precedence() > precedence {
 		p.advance()
 		switch p.current.Kind {
 		case token.Or,

--- a/internal/syntax/parser/parser_test.go
+++ b/internal/syntax/parser/parser_test.go
@@ -55,7 +55,7 @@ func TestParseVarStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -98,7 +98,7 @@ func TestParseReturnStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -141,7 +141,7 @@ func TestParsePrintStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -184,7 +184,7 @@ func TestParseIdent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -257,7 +257,7 @@ func TestParseNumber(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -315,7 +315,7 @@ func TestParseBool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -397,7 +397,7 @@ func TestParseUnaryExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -665,7 +665,7 @@ func TestParseBinaryExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -715,7 +715,7 @@ func TestParseGroupedExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -847,7 +847,7 @@ func TestOperatorPrecedence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src)
+			p := parser.New(t.Name(), tt.src, false)
 			prog, err := p.Parse()
 			test.Ok(t, err, test.Context("unexpected parse error"))
 

--- a/internal/syntax/parser/parser_test.go
+++ b/internal/syntax/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"io"
 	"slices"
 	"testing"
 
@@ -55,7 +56,7 @@ func TestParseVarStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -98,7 +99,7 @@ func TestParseReturnStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -141,7 +142,7 @@ func TestParsePrintStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -184,7 +185,7 @@ func TestParseIdent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -257,7 +258,7 @@ func TestParseNumber(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -315,7 +316,7 @@ func TestParseBool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -397,7 +398,7 @@ func TestParseUnaryExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -665,7 +666,7 @@ func TestParseBinaryExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -715,7 +716,7 @@ func TestParseGroupedExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -847,7 +848,7 @@ func TestOperatorPrecedence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, false)
+			p := parser.New(t.Name(), tt.src, true, io.Discard)
 			prog, err := p.Parse()
 			test.Ok(t, err, test.Context("unexpected parse error"))
 

--- a/internal/syntax/parser/parser_test.go
+++ b/internal/syntax/parser/parser_test.go
@@ -1,7 +1,8 @@
 package parser_test
 
 import (
-	"io"
+	"flag"
+	"os"
 	"slices"
 	"testing"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/FollowTheProcess/glox/internal/syntax/token"
 	"github.com/FollowTheProcess/test"
 )
+
+var debug = flag.Bool("debug", false, "Emit parse traces to stderr during tests")
 
 // parseTest is a table driven test where we parse a full program and make assertions
 // about the AST that gets produced.
@@ -56,7 +59,7 @@ func TestParseVarStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -99,7 +102,7 @@ func TestParseReturnStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -142,7 +145,7 @@ func TestParsePrintStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -185,7 +188,7 @@ func TestParseIdent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -258,7 +261,7 @@ func TestParseNumber(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -316,7 +319,7 @@ func TestParseBool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -398,7 +401,7 @@ func TestParseUnaryExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -666,7 +669,7 @@ func TestParseBinaryExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -716,7 +719,7 @@ func TestParseGroupedExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			got, err := p.Parse()
 
 			// Whether or not we wanted an error is encoded in the length of tt.errs:
@@ -848,7 +851,7 @@ func TestOperatorPrecedence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parser.New(t.Name(), tt.src, true, io.Discard)
+			p := parser.New(t.Name(), tt.src, *debug, os.Stderr)
 			prog, err := p.Parse()
 			test.Ok(t, err, test.Context("unexpected parse error"))
 


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->

Now accepts a `--debug` flag which will output parser traces that look like this:

<img width="568" alt="Screenshot 2025-03-01 at 08 28 29" src="https://github.com/user-attachments/assets/fb3a2558-9be5-464e-8bb5-d8a0dc822ad7" />
